### PR TITLE
Add total number of adjacent mines to the cell, but hidden by default

### DIFF
--- a/src/board/ui/renderBoard.ts
+++ b/src/board/ui/renderBoard.ts
@@ -30,6 +30,13 @@ export const renderBoard = (board: Board): void => {
         mineImageElement.height = 40;
         cellElement.appendChild(mineImageElement);
       }
+
+      if (!cell.hasMine) {
+        const adjacentMinesTotalElement = document.createElement("span");
+        adjacentMinesTotalElement.textContent = String(cell.adjacentMinesTotal);
+        adjacentMinesTotalElement.className = "hidden";
+        cellElement.appendChild(adjacentMinesTotalElement);
+      }
     });
   });
 


### PR DESCRIPTION
While rendering board, add condition if `cellElement` has not a mine, then add a span to show total number of adjacent mines